### PR TITLE
refactor: header in service for product requests

### DIFF
--- a/src/app/services/orderProduct.service.ts
+++ b/src/app/services/orderProduct.service.ts
@@ -12,15 +12,19 @@ export class OrderProductService {
   private pollingInterval = 1200000; //1200000 (para dejar cuando no quiero que cambie tan seguido)
 
   constructor(private http: HttpClient) { }
+
+  // La constante headers es igual en todos los métodos del servicio:
+  headers = new HttpHeaders({
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${localStorage.getItem('accesToken')}`,
+  });
+
   // Crea una orden
   postOrder(data: NewOrder): Observable<ResponseOrder> {
     const direction = this.apiUrl + 'orders';
-    const headers = new HttpHeaders({
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${localStorage.getItem('accesToken')}`,
-    });
+
     const orderInfo =  data;
-    const options = { headers: headers };
+    const options = { headers: this.headers };
 
     return this.http.post<ResponseOrder>(direction, orderInfo, options);
   }
@@ -28,11 +32,8 @@ export class OrderProductService {
   // Obtiene órdenes procesadas y también las delivered PARECE
   getOrders(): Observable<RPOrder[]> {
     const direction = this.apiUrl + 'orders';
-    const headers = new HttpHeaders({
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${localStorage.getItem('accesToken')}`,
-    });
-    const options = {headers: headers};
+
+    const options = {headers: this.headers};
 
     return timer(0, this.pollingInterval).pipe(
       switchMap(() => this.http.get<RPOrder[]>(direction, options))
@@ -42,11 +43,8 @@ export class OrderProductService {
   // Obtiene las órdenes que están listas (?)
   getOrdersReady(): Observable<ProcessedOrder[]> {
     const direction = this.apiUrl + 'orders';
-    const headers = new HttpHeaders({
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${localStorage.getItem('accesToken')}`,
-    });
-    const options = {headers: headers};
+
+    const options = {headers: this.headers};
 
     return timer(0, this.pollingInterval).pipe(
       switchMap(() => this.http.get<ProcessedOrder[]>(direction, options))
@@ -56,31 +54,25 @@ export class OrderProductService {
   // para cambiar los pedidos a que están listos para se entregados
   processOrder(id: number): Observable<ProcessedOrder> {
     const direction = this.apiUrl + `orders/${id}`;
-    const headers = new HttpHeaders({
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${localStorage.getItem('accesToken')}`,
-    });
+
     const orderInfo = {
       status: 'delivering', // se cambió a delivering siguiendo el schema (previo a delivered, cuando ya está listo)
       // dateProcessed: new Date(),  Esto sólo queda como delivering, sin fecha nueva
       // OJO, VER CÓMO HACER PARA CALCULAR EL TIEMPO SI ES QUE NO HAY UNA FECHA ADICIONAL ESTA VEZ
     }
-    const options = { headers: headers };
+    const options = { headers: this.headers };
     return this.http.patch<ProcessedOrder>(direction, orderInfo, options);
   }
 
 
   markReady(id: number): Observable<ProcessedOrder> {
     const direction = this.apiUrl + `orders/${id}`;
-    const headers = new HttpHeaders({
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${localStorage.getItem('accesToken')}`,
-    });
+
     const orderInfo = {
       status: 'delivered',
       dateProcessed: new Date(), // Aquí ya lleva fecha nueva, porque ya fue entregado
     }
-    const options = { headers: headers };
+    const options = { headers: this.headers };
     return this.http.patch<ProcessedOrder>(direction, orderInfo, options);
   }
 


### PR DESCRIPTION
The header in the api request in the services is the same in all methods, so it was declared as a global variable in the component.